### PR TITLE
Fix broken HASH function and add debugging

### DIFF
--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -2,6 +2,7 @@
 SLOT=7
 DISK="/dev/sda3"
 CLEAR_SLOT=0
+DBG=0
 TMP_FILE=/tmp/new_key
 set -e
 . /etc/ykluks.cfg
@@ -11,7 +12,7 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-while getopts ":s:d:hc" opt; do
+while getopts ":s:d:hcv" opt; do
   case $opt in
 	s)
 		SLOT=$OPTARG
@@ -24,11 +25,15 @@ while getopts ":s:d:hc" opt; do
 	c)      CLEAR_SLOT=1
 		echo "clearing slot"
 		;;
+	v)      DBG=1
+		echo "debugging enabled"
+		;;
 	h)
 		echo 
 		echo " -d <partition>: set the partition"
 		echo " -s <slot>     : set the slot"
                 echo " -c            : clear the slot prior to writing"
+                echo " -v            : show input/output in cleartext"
 		echo
 		exit 1
 		;;
@@ -44,27 +49,40 @@ if [ $CLEAR_SLOT -eq 1 ]; then
 	echo "Killing LUKS slot $SLOT"
 	cryptsetup luksKillSlot "$DISK" "$SLOT"
 fi
+
 echo "Adding yubikey to initrd"
 P1=$(/lib/cryptsetup/askpass "Please insert a yubikey and enter a new password. This is the password that will only work while your yubikey is installed in your computer.")
+	if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
+
 P2=$(/lib/cryptsetup/askpass "Please enter the yubikey password again:")
+	if [ "$DBG" = "1" ]; then echo "Password: $P2"; fi
+
 if [ "$P1" != "$P2" ]; then
 	echo "Passwords do not match"
 	exit 1
+fi
 
 if [ "$HASH" = "1" ]; then
-	P1=$(printf %s "$P1" | sha256sum | awk '{print $1}') 
+	P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')
+		if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 
-fi
 echo "You may now be prompted for an existing passphrase. This is NOT the passphrase you just entered, this is the passphrase that you currently use to unlock your LUKS encrypted drive."
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
+	if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
+
 touch $TMP_FILE
 chmod 600 $TMP_FILE
+
 if [ "$CONCATENATE" = "1" ]; then
 	echo -n "$P1$R" > $TMP_FILE
+		if [ "$DBG" = "1" ]; then echo "LUKS key: $P1$R"; fi
 else
 	echo -n "$R" > $TMP_FILE
+		if [ "$DBG" = "1" ]; then echo "LUKS key: $R"; fi
 fi
+
 cryptsetup --key-slot="$SLOT" luksAddKey "$DISK" $TMP_FILE
 shred -u $TMP_FILE
+
 exit 0


### PR DESCRIPTION
HASH function is currently broken in yubikey-luks-enroll script (it doesn't trigger). I'm very sorry for this. This PR fixes it and adds -v argument for debugging which can catch such issues. It's also useful for users who wan't to know what this tool really do with their keys.